### PR TITLE
Initial aleph redirector application 

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,0 +1,10 @@
+# Only set common, public settings here. This file can be in version control.
+# Use .env for secrects and DO NOT CHECK IN .env
+
+# This is the lowest priority place to set ENV so these are effectively
+# defaults that can locally be overriden with .env and production overriden
+# by setting env appropriate to your platform.
+
+FLASK_APP=redirector
+FLASK_ENV=development
+TARGET_URL=https://libraries.mit.edu/news/library-platform-before/32066/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip pipenv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip pipenv
+          pipenv install --dev
+      - name: Test with pytest
+        run: |
+          pipenv run pytest
+          pipenv run coveralls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,3 @@ jobs:
       - name: Test with pytest
         run: |
           pipenv run pytest
-          pipenv run coveralls

--- a/Pipfile
+++ b/Pipfile
@@ -13,4 +13,4 @@ pytest = "*"
 python-dotenv = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+flask = "*"
+gunicorn = "*"
+
+[dev-packages]
+flake8 = "*"
+pytest = "*"
+python-dotenv = "*"
+
+[requires]
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7472358f8951d9347c5bad18fa98dfa7628eb31cbfa17134e9b8dda4c55d865e"
+            "sha256": "86848acf8d800d259af92d85b5503e3d722e4e7e7fbcdb5d347e46b761597493"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.9"
         },
         "sources": [
             {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,212 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "7472358f8951d9347c5bad18fa98dfa7628eb31cbfa17134e9b8dda4c55d865e"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "click": {
+            "hashes": [
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.0.1"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:1c4c257b1892aec1398784c63791cbaa43062f1f7aeb555c4da961b20ee68f55",
+                "sha256:a6209ca15eb63fc9385f38e452704113d679511d9574d09b2cf9183ae7d20dc9"
+            ],
+            "index": "pypi",
+            "version": "==2.0.1"
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e",
+                "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"
+            ],
+            "index": "pypi",
+            "version": "==20.1.0"
+        },
+        "itsdangerous": {
+            "hashes": [
+                "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
+                "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4",
+                "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.1"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42",
+                "sha256:6c1ec500dcdba0baa27600f6a22f6333d8b662d22027ff9f6202e3367413caa8"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
+        }
+    },
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b",
+                "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"
+            ],
+            "index": "pypi",
+            "version": "==3.9.2"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.9"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068",
+                "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.7.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3",
+                "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.3.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+            ],
+            "index": "pypi",
+            "version": "==6.2.4"
+        },
+        "python-dotenv": {
+            "hashes": [
+                "sha256:00aa34e92d992e9f8383730816359647f358f4a3be1ba45e5a5cefd27ee91544",
+                "sha256:b1ae5e9643d5ed987fc57cc2583021e38db531946518130777734f9589b3141f"
+            ],
+            "index": "pypi",
+            "version": "==0.17.1"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        }
+    }
+}

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn redirector:app --log-file -

--- a/docs/architecture-decisions/0002-permalinks-should-have-transitions-to-new-systems.md
+++ b/docs/architecture-decisions/0002-permalinks-should-have-transitions-to-new-systems.md
@@ -1,0 +1,48 @@
+# 2. Permalinks should have transitions to new systems
+
+Date: 2021-05-27
+
+## Status
+
+Accepted
+
+## Context
+
+We are migrating from Aleph to Alma / Primo. Aleph had a system for creating
+persistent links to records that we advertised as permalinks.
+
+Example:
+
+```text
+Permalink for this record: http://library.mit.edu/item/001264079
+```
+
+Those links have been included in websites and user bookmarks for a decade.
+
+We can choose to redirect all traffic to library.mit.edu to a generic page that
+explains that we have moved systems, or we can try to use our knowledge of both
+Aleph and Primo to both tell the user the old system has been retired while
+providing them with an equivalent new _persistent_ link in Primo -- a link
+which we should use care in refering to as _persistent_ and not _permanent_ if
+unless we intend to support it across system transitions.
+
+## Decision
+
+As we advertised permalinks, we should make an effort to not only tell people a
+system was shut down they were using, but provide them with a likely link to the
+same record in the new system.
+
+We will not maintain this linkage forever, but will use care in our status
+codes to inform search engines to remove the old link while informing users
+that the automatic redirecting will only remain for a specified period of time.
+
+## Consequences
+
+Our users and websites that are using Aleph permalinks will continue to have
+access to the same information in Alma.
+
+We will need to create a smarter redirect rather than relying on 404ing
+everything to a single page that explains the system migration.
+
+We need to convey to users that this is a temporary solution and will be
+retired on a specific date so they should update bookmarks and webpages.

--- a/docs/architecture-decisions/0003-use-flask.md
+++ b/docs/architecture-decisions/0003-use-flask.md
@@ -1,0 +1,22 @@
+# 3. Use Flask
+
+Date: 2021-05-27
+
+## Status
+
+Accepted
+
+## Context
+
+This application needs to do very little and as such does not need a heavy
+framework to succeed.
+
+## Decision
+
+We will use Flask.
+
+## Consequences
+
+Using Flask provides a solution that is appropriate for the scale of application
+we will be using, while using Python and Flask which are well understood by
+existing engineers in our organization.

--- a/redirector/__init__.py
+++ b/redirector/__init__.py
@@ -1,0 +1,30 @@
+import logging
+import os
+
+from flask import Flask, redirect
+
+
+app = Flask(__name__)
+app.config['TARGET_URL'] = os.getenv('TARGET_URL')
+logging.basicConfig(level=logging.INFO)
+
+
+@app.route('/', defaults={'u_path': ''})
+@app.route('/<path:u_path>')
+# handles generic redirects for all requests that don't match a more specific
+# pattern
+def generic_redirect(u_path):
+    url = app.config['TARGET_URL']
+    return redirect(url, code=308)
+
+
+@ app.route('/item/<string:aleph_id>')
+# handles aleph permalink syntax http://library.mit.edu/item/001264079
+def redirect_with_bibid(aleph_id):
+    url = app.config['TARGET_URL']
+    return redirect(f'{url}?aleph_id={aleph_id}', code=308)
+
+
+@ app.route('/ping')
+def ping():
+    return 'pong'

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,0 +1,34 @@
+import pytest
+import redirector
+
+
+@pytest.fixture
+def client():
+    redirector.app.config['TESTING'] = True
+    redirector.app.config['TARGET_URL'] = 'http://example.com/hallo/'
+
+    with redirector.app.test_client() as client:
+        yield client
+
+
+def test_ping(client):
+    rv = client.get('/ping')
+    assert b'pong' in rv.data
+
+
+def test_redirect_with_no_args(client):
+    response = client.get('/')
+    url = 'http://example.com/hallo/'
+    assert url in response.location
+
+
+def test_redirect_with_non_permalink_pattern(client):
+    response = client.get('/i/am/a/non/handled/path')
+    url = 'http://example.com/hallo/'
+    assert url in response.location
+
+
+def test_redirect_with_permalink_pattern(client):
+    response = client.get('/item/123')
+    url = 'http://example.com/hallo/?aleph_id=123'
+    assert url in response.location


### PR DESCRIPTION
Why are these changes being introduced:

* As Aleph is being retired, we need a solution to redirect users with
  bookmarks, webpages with links, and search engines
* This solution explores having a generic solution for most link
  patterns, but introduces the start of a solution to provide additional
  context -- or possibly a direct link eventually -- for the specific
  pattern of aleph permalinks

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2053

How does this address that need:

* The flask application in this commit addresses the initial work we can
  use to explore whether this is the direction we will take to solve
  this problem

Document any side effects to this change:

At this time, the data to actually provide the new links into Primo are
not available to this application (or the generic WordPress page) to
actually _do_ the linking to the new Primo page.

Multiple options will be explored:

- using searches in Primo UI. This aleph id is _in_ Primo, but not
  currently searchable
- using TIMDEX. We have not yet loaded the Alma data into TIMDEX, but
  once that work is done, we should be able to search the old Aleph ID
  and retrieve the data neccesary to link to the correct record in
  Primo UI
- using Alma SRU (this has been poked at a bit and seems very promising)