### PR TITLE
Redirect aleph permalink pattern to Primo 

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -7,6 +7,3 @@
 
 FLASK_APP=redirector
 FLASK_ENV=development
-TARGET_URL=https://libraries.mit.edu/news/library-platform-before/32066/
-ALMA_SRU=https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?version=1.2&operation=searchRetrieve&recordSchema=dc&query=alma.all_for_ui=
-PRIMO_URL=https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT&docid=

--- a/.flaskenv
+++ b/.flaskenv
@@ -8,3 +8,5 @@
 FLASK_APP=redirector
 FLASK_ENV=development
 TARGET_URL=https://libraries.mit.edu/news/library-platform-before/32066/
+ALMA_SRU=https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?version=1.2&operation=searchRetrieve&recordSchema=dc&query=alma.all_for_ui=
+PRIMO_URL=https://mit.primo.exlibrisgroup.com/discovery/fulldisplay?vid=01MIT_INST:MIT&docid=

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2021 Massachusetts Institute of Technology
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,8 @@ name = "pypi"
 [packages]
 flask = "*"
 gunicorn = "*"
+requests = "*"
+pytest-recording = "*"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "86848acf8d800d259af92d85b5503e3d722e4e7e7fbcdb5d347e46b761597493"
+            "sha256": "9081bb805969d99b709c21c885473a6b00afbc1ea7c990d0ddbe4f35e9d07e84"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,29 @@
         ]
     },
     "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
+                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+            ],
+            "version": "==2021.5.30"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
+                "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.0.0"
+        },
         "click": {
             "hashes": [
                 "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
@@ -39,6 +62,21 @@
             ],
             "index": "pypi",
             "version": "==20.1.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
+                "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.10"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
         },
         "itsdangerous": {
             "hashes": [
@@ -96,6 +134,172 @@
             "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
         },
+        "multidict": {
+            "hashes": [
+                "sha256:018132dbd8688c7a69ad89c4a3f39ea2f9f33302ebe567a879da8f4ca73f0d0a",
+                "sha256:051012ccee979b2b06be928a6150d237aec75dd6bf2d1eeeb190baf2b05abc93",
+                "sha256:05c20b68e512166fddba59a918773ba002fdd77800cad9f55b59790030bab632",
+                "sha256:07b42215124aedecc6083f1ce6b7e5ec5b50047afa701f3442054373a6deb656",
+                "sha256:0e3c84e6c67eba89c2dbcee08504ba8644ab4284863452450520dad8f1e89b79",
+                "sha256:0e929169f9c090dae0646a011c8b058e5e5fb391466016b39d21745b48817fd7",
+                "sha256:1ab820665e67373de5802acae069a6a05567ae234ddb129f31d290fc3d1aa56d",
+                "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5",
+                "sha256:2e68965192c4ea61fff1b81c14ff712fc7dc15d2bd120602e4a3494ea6584224",
+                "sha256:2f1a132f1c88724674271d636e6b7351477c27722f2ed789f719f9e3545a3d26",
+                "sha256:37e5438e1c78931df5d3c0c78ae049092877e5e9c02dd1ff5abb9cf27a5914ea",
+                "sha256:3a041b76d13706b7fff23b9fc83117c7b8fe8d5fe9e6be45eee72b9baa75f348",
+                "sha256:3a4f32116f8f72ecf2a29dabfb27b23ab7cdc0ba807e8459e59a93a9be9506f6",
+                "sha256:46c73e09ad374a6d876c599f2328161bcd95e280f84d2060cf57991dec5cfe76",
+                "sha256:46dd362c2f045095c920162e9307de5ffd0a1bfbba0a6e990b344366f55a30c1",
+                "sha256:4b186eb7d6ae7c06eb4392411189469e6a820da81447f46c0072a41c748ab73f",
+                "sha256:54fd1e83a184e19c598d5e70ba508196fd0bbdd676ce159feb412a4a6664f952",
+                "sha256:585fd452dd7782130d112f7ddf3473ffdd521414674c33876187e101b588738a",
+                "sha256:5cf3443199b83ed9e955f511b5b241fd3ae004e3cb81c58ec10f4fe47c7dce37",
+                "sha256:6a4d5ce640e37b0efcc8441caeea8f43a06addace2335bd11151bc02d2ee31f9",
+                "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359",
+                "sha256:806068d4f86cb06af37cd65821554f98240a19ce646d3cd24e1c33587f313eb8",
+                "sha256:830f57206cc96ed0ccf68304141fec9481a096c4d2e2831f311bde1c404401da",
+                "sha256:929006d3c2d923788ba153ad0de8ed2e5ed39fdbe8e7be21e2f22ed06c6783d3",
+                "sha256:9436dc58c123f07b230383083855593550c4d301d2532045a17ccf6eca505f6d",
+                "sha256:9dd6e9b1a913d096ac95d0399bd737e00f2af1e1594a787e00f7975778c8b2bf",
+                "sha256:ace010325c787c378afd7f7c1ac66b26313b3344628652eacd149bdd23c68841",
+                "sha256:b47a43177a5e65b771b80db71e7be76c0ba23cc8aa73eeeb089ed5219cdbe27d",
+                "sha256:b797515be8743b771aa868f83563f789bbd4b236659ba52243b735d80b29ed93",
+                "sha256:b7993704f1a4b204e71debe6095150d43b2ee6150fa4f44d6d966ec356a8d61f",
+                "sha256:d5c65bdf4484872c4af3150aeebe101ba560dcfb34488d9a8ff8dbcd21079647",
+                "sha256:d81eddcb12d608cc08081fa88d046c78afb1bf8107e6feab5d43503fea74a635",
+                "sha256:dc862056f76443a0db4509116c5cd480fe1b6a2d45512a653f9a855cc0517456",
+                "sha256:ecc771ab628ea281517e24fd2c52e8f31c41e66652d07599ad8818abaad38cda",
+                "sha256:f200755768dc19c6f4e2b672421e0ebb3dd54c38d5a4f262b872d8cfcc9e93b5",
+                "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281",
+                "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.1.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.9"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.2.4"
+        },
+        "pytest-recording": {
+            "hashes": [
+                "sha256:c2cc321f93ceffb2146ead0c51198e4ce86986723265ce6d4a87d3b16071eb85",
+                "sha256:deea1ae6a129c9d8f8669ed7d12539748f00c8f9ef4de4f563055263e47bed08"
+            ],
+            "index": "pypi",
+            "version": "==0.11.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
+                "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
+            ],
+            "index": "pypi",
+            "version": "==2.25.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
+                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.5"
+        },
+        "vcrpy": {
+            "hashes": [
+                "sha256:12c3fcdae7b88ecf11fc0d3e6d77586549d4575a2ceee18e82eee75c1f626162",
+                "sha256:57095bf22fc0a2d99ee9674cdafebed0f3ba763018582450706f7d3a74fff599"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==4.1.1"
+        },
         "werkzeug": {
             "hashes": [
                 "sha256:1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42",
@@ -103,6 +307,55 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
+            ],
+            "version": "==1.12.1"
+        },
+        "yarl": {
+            "hashes": [
+                "sha256:00d7ad91b6583602eb9c1d085a2cf281ada267e9a197e8b7cae487dadbfa293e",
+                "sha256:0355a701b3998dcd832d0dc47cc5dedf3874f966ac7f870e0f3a6788d802d434",
+                "sha256:15263c3b0b47968c1d90daa89f21fcc889bb4b1aac5555580d74565de6836366",
+                "sha256:2ce4c621d21326a4a5500c25031e102af589edb50c09b321049e388b3934eec3",
+                "sha256:31ede6e8c4329fb81c86706ba8f6bf661a924b53ba191b27aa5fcee5714d18ec",
+                "sha256:324ba3d3c6fee56e2e0b0d09bf5c73824b9f08234339d2b788af65e60040c959",
+                "sha256:329412812ecfc94a57cd37c9d547579510a9e83c516bc069470db5f75684629e",
+                "sha256:4736eaee5626db8d9cda9eb5282028cc834e2aeb194e0d8b50217d707e98bb5c",
+                "sha256:4953fb0b4fdb7e08b2f3b3be80a00d28c5c8a2056bb066169de00e6501b986b6",
+                "sha256:4c5bcfc3ed226bf6419f7a33982fb4b8ec2e45785a0561eb99274ebbf09fdd6a",
+                "sha256:547f7665ad50fa8563150ed079f8e805e63dd85def6674c97efd78eed6c224a6",
+                "sha256:5b883e458058f8d6099e4420f0cc2567989032b5f34b271c0827de9f1079a424",
+                "sha256:63f90b20ca654b3ecc7a8d62c03ffa46999595f0167d6450fa8383bab252987e",
+                "sha256:68dc568889b1c13f1e4745c96b931cc94fdd0defe92a72c2b8ce01091b22e35f",
+                "sha256:69ee97c71fee1f63d04c945f56d5d726483c4762845400a6795a3b75d56b6c50",
+                "sha256:6d6283d8e0631b617edf0fd726353cb76630b83a089a40933043894e7f6721e2",
+                "sha256:72a660bdd24497e3e84f5519e57a9ee9220b6f3ac4d45056961bf22838ce20cc",
+                "sha256:73494d5b71099ae8cb8754f1df131c11d433b387efab7b51849e7e1e851f07a4",
+                "sha256:7356644cbed76119d0b6bd32ffba704d30d747e0c217109d7979a7bc36c4d970",
+                "sha256:8a9066529240171b68893d60dca86a763eae2139dd42f42106b03cf4b426bf10",
+                "sha256:8aa3decd5e0e852dc68335abf5478a518b41bf2ab2f330fe44916399efedfae0",
+                "sha256:97b5bdc450d63c3ba30a127d018b866ea94e65655efaf889ebeabc20f7d12406",
+                "sha256:9ede61b0854e267fd565e7527e2f2eb3ef8858b301319be0604177690e1a3896",
+                "sha256:b2e9a456c121e26d13c29251f8267541bd75e6a1ccf9e859179701c36a078643",
+                "sha256:b5dfc9a40c198334f4f3f55880ecf910adebdcb2a0b9a9c23c9345faa9185721",
+                "sha256:bafb450deef6861815ed579c7a6113a879a6ef58aed4c3a4be54400ae8871478",
+                "sha256:c49ff66d479d38ab863c50f7bb27dee97c6627c5fe60697de15529da9c3de724",
+                "sha256:ce3beb46a72d9f2190f9e1027886bfc513702d748047b548b05dab7dfb584d2e",
+                "sha256:d26608cf178efb8faa5ff0f2d2e77c208f471c5a3709e577a7b3fd0445703ac8",
+                "sha256:d597767fcd2c3dc49d6eea360c458b65643d1e4dbed91361cf5e36e53c1f8c96",
+                "sha256:d5c32c82990e4ac4d8150fd7652b972216b204de4e83a122546dce571c1bdf25",
+                "sha256:d8d07d102f17b68966e2de0e07bfd6e139c7c02ef06d3a0f8d2f0f055e13bb76",
+                "sha256:e46fba844f4895b36f4c398c5af062a9808d1f26b2999c58909517384d5deda2",
+                "sha256:e6b5460dc5ad42ad2b36cca524491dfcaffbfd9c8df50508bddc354e787b8dc2",
+                "sha256:f040bcc6725c821a4c0665f3aa96a4d0805a7aaf2caf266d256b8ed71b9f041c",
+                "sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a",
+                "sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.6.3"
         }
     },
     "develop": {
@@ -189,7 +442,7 @@
                 "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
                 "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==6.2.4"
         },
         "python-dotenv": {

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Aleph to Alma redirector
+
+## Purpose
+
+This application is intended to help with the transition from our Aleph ILS to
+our Alma / Primo implementation.
+
+Most URLs we want to redirect to a page that clarifies the system changes.
+
+Specific patterns of URLs, namely the Aleph Permalink pattern, we want to
+assist users to find the same record in Primo.
+
+## Development
+
+Clone the repo and install the dependencies using Pipenv:
+
+```shell
+git clone git@github.com:MITLibraries/aleph_redirector.git
+
+cd aleph_redirector
+
+pipenv shell
+
+pipenv install --dev
+
+flask run
+```
+
+## Running tests locally
+
+Follow above development installation instructions.
+
+`pytest`
+
+## Generating (or regenerating) cassettes
+
+To (re)generate cassettes (cached responses)
+
+`pytest --record-mode=rewrite`

--- a/docs/architecture-decisions/0004-use-alma-sru.md
+++ b/docs/architecture-decisions/0004-use-alma-sru.md
@@ -1,0 +1,40 @@
+# 4. Use Alma SRU
+
+Date: 2021-06-03
+
+## Status
+
+Accepted
+
+## Context
+
+We need a way to translate a supplied Aleph ID into an Alma ID suitable for use
+in linking to a full record view in Primo UI.
+
+Options include:
+
+- [Alma Bibliographic Records and Inventory API](https://developers.exlibrisgroup.com/alma/apis/bibs/)
+- [Alma SRU](https://developers.exlibrisgroup.com/alma/integrations/sru/)
+- [TIMDEX](https://timdex.mit.edu)
+
+Alma SRU is openly available with no API key or IP restrictions.
+
+TIMDEX does not yet have this data loaded.
+
+## Decision
+
+Alma SRU works well for this use case, is openly available, and is ready for
+this use case immediately.
+
+We will use Alma SRU.
+
+## Consequences
+
+As we learn more about Alma SRU and Alma Bib API, we may find that this use case
+fits better with the Alma Bib API.
+
+Additionally, when TIMDEX is updated to have the necessary Alma records, we may
+want to centralize on our internal discovery API.
+
+Changing to use either of those other options is relatively minimal effort and
+we should do so if they become preferred for this use case in the future.

--- a/redirector/__init__.py
+++ b/redirector/__init__.py
@@ -1,11 +1,15 @@
 import logging
 import os
 
-from flask import Flask, redirect
+import requests
 
+from flask import Flask, redirect
+from xml.etree.ElementTree import fromstring, ElementTree
 
 app = Flask(__name__)
 app.config['TARGET_URL'] = os.getenv('TARGET_URL')
+app.config['ALMA_SRU'] = os.getenv('ALMA_SRU')
+app.config['PRIMO_URL'] = os.getenv('PRIMO_URL')
 logging.basicConfig(level=logging.INFO)
 
 
@@ -21,10 +25,42 @@ def generic_redirect(u_path):
 @ app.route('/item/<string:aleph_id>')
 # handles aleph permalink syntax http://library.mit.edu/item/001264079
 def redirect_with_bibid(aleph_id):
-    url = app.config['TARGET_URL']
-    return redirect(f'{url}?aleph_id={aleph_id}', code=308)
+    url, code = alma_lookup(aleph_id)
+    return redirect(url, code)
 
 
 @ app.route('/ping')
 def ping():
     return 'pong'
+
+
+def alma_lookup(aleph_id):
+    # <subfield code="a">(MCM)000157165MIT01</subfield>
+    # https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?version=1.2&operation=searchRetrieve&recordSchema=marcxml&query=alma.all_for_ui=000095961MIT01
+    alma_sru = app.config['ALMA_SRU'] + aleph_id + 'MIT01'
+    retrieve = requests.get(alma_sru)
+    url = app.config['TARGET_URL']
+    code = 308
+
+    if retrieve.status_code != 200:
+        logging.info(f"Alma response code: {retrieve.status_code}")
+        return url, code
+
+    tree = ElementTree(fromstring(retrieve.content))
+
+    root = tree.getroot()
+
+    if 'errors' in root:
+        logging.info('Errors in data returned from Alma')
+        return url, code
+
+    ns = {'x': 'http://www.loc.gov/zing/srw/'}
+
+    # if we get exactly one record back, it's the one we want so redirct to it
+    if len(tree.findall(".//x:record/x:recordIdentifier", ns)) == 1:
+        url = app.config['PRIMO_URL']
+        alma_id = tree.findall(".//x:record/x:recordIdentifier", ns)[0]
+
+        return f'{url}alma{alma_id.text}', code
+
+    return url, code

--- a/redirector/__init__.py
+++ b/redirector/__init__.py
@@ -6,10 +6,18 @@ import requests
 from flask import Flask, redirect
 from xml.etree.ElementTree import fromstring, ElementTree
 
-app = Flask(__name__)
-app.config['TARGET_URL'] = os.getenv('TARGET_URL')
-app.config['ALMA_SRU'] = os.getenv('ALMA_SRU')
-app.config['PRIMO_URL'] = os.getenv('PRIMO_URL')
+app = Flask(__name__, instance_relative_config=True)
+
+flask_env = os.getenv('FLASK_ENV')
+
+if flask_env == 'development':
+    app.config.from_object('redirector.config.DevelopmentConfig')
+elif flask_env == 'production':
+    app.config.from_object('redirector.config.Config')
+else:
+    app.config.from_object('redirector.config.TestingConfig')
+
+
 logging.basicConfig(level=logging.INFO)
 
 

--- a/redirector/config.py
+++ b/redirector/config.py
@@ -1,0 +1,25 @@
+import os
+
+
+class Config():
+    DEBUG = os.getenv('FLASK_DEBUG', default=False)
+    ENV = os.getenv('FLASK_ENV', default='production')
+
+    ALMA_SRU = os.getenv('ALMA_SRU')
+    PRIMO_URL = os.getenv('PRIMO_URL')
+    TARGET_URL = os.getenv('TARGET_URL')
+
+
+class DevelopmentConfig(Config):
+    DEBUG = True
+    ENV = 'development'
+
+
+class TestingConfig(Config):
+    DEBUG = True
+    TESTING = True
+    ENV = 'testing'
+
+    ALMA_SRU = 'https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?version=1.2&operation=searchRetrieve&recordSchema=dc&query=alma.all_for_ui='
+    PRIMO_URL = 'http://example.com/primo/'
+    TARGET_URL = 'http://example.com/hallo/'

--- a/tests/cassettes/test_redirects/test_redirect_to_generic_with_permalink_pattern_no_match.yaml
+++ b/tests/cassettes/test_redirects/test_redirect_to_generic_with_permalink_pattern_no_match.yaml
@@ -1,0 +1,44 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?version=1.2&operation=searchRetrieve&recordSchema=dc&query=alma.all_for_ui=asdfasdfasfasdfasdfasdfMIT01
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?><searchRetrieveResponse
+        xmlns=\"http://www.loc.gov/zing/srw/\">\n  <version>1.2</version>\n  <numberOfRecords>0</numberOfRecords>\n
+        \ <records/>\n  <extraResponseData xmlns:xb=\"http://www.exlibris.com/repository/search/xmlbeans/\">\n
+        \   <xb:exact>true</xb:exact>\n    <xb:responseDate>2021-06-03T14:29:16-0400</xb:responseDate>\n
+        \ </extraResponseData>\n</searchRetrieveResponse>"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '420'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Thu, 03 Jun 2021 18:29:15 GMT
+      Keep-Alive:
+      - timeout=20
+      Set-Cookie:
+      - JSESSIONID="1E3CFD831C60E2049B4009006A827543.app04.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801";
+        Version=1; Path=/; HttpOnly; SameSite=None; Secure
+      - urm_st=1622744956097; Path=/; SameSite=None; Secure
+      - urm_se=1622745556097; Path=/; SameSite=None; Secure
+      - X-Persist=a556d7ef198f1c1dd429ddf70584774a;Path=/;SameSite=None;Secure
+      p3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/tests/cassettes/test_redirects/test_redirect_with_permalink_pattern.yaml
+++ b/tests/cassettes/test_redirects/test_redirect_with_permalink_pattern.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?version=1.2&operation=searchRetrieve&recordSchema=dc&query=alma.all_for_ui=000095961MIT01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAJ1WW2/aMBR+76+w8rRKJU5YSwGFTCzt1khQKmBoe5oc55R4DXZkOwX26+ckEC69
+        bAwJ4XP8fefmYx+8T6tFip5BKiZ4z3Jtx0LAqYgZn/esb9MvjbaFlCY8Jqng0LO4sD75ngIiaTIG
+        LRk8wxhUJrgCZGxx1bMSrbMuxsvl0k4FtefiGf829rCSS2z5Zwh5G4e+azc9vBWKDZ4vIpCjxzFQ
+        IWPlux4+VhUwuVvXUiXU4oQmsCB+TD18oDhEPRD6ZELzTeRb3FZ1CLwhuuYapUnlZ0y7Ma1yNos6
+        7SyXqS3kHMcUQwoL4Fph13axtcFW3J7F+KMoBKzKyLBrGI1qvYWuFDso5/JjabnpOC7+PhxUKTUY
+        L06IgmEp1q0sDAQlujzTd9ygV06qOmxTXHNcuSmJErmkoHYke6Via1cKUwxTCM10Cv40AcUU0tUP
+        9nC9cwSngpvWiXItpD8gT3CBJgmkKaztkrO//Q5zSJQiNMkVaK1QaKrAdK4BiUc0BZpwkYr52kY3
+        kBGpi3ModvqmcZkGqnMJf/Wm1xn4Gla6SqWQjhAx0eBTt3PdqYyV8muYAvImIiV8npM5+MDnJahW
+        HJsCRSXLipPdVvvD0J7YM/M9bzT+qSIXRUW0fVyMC7SXxZ6bdyIYhsF49CUM7m5RMHr4gfqzfjjo
+        fx7covAe9cfBXTi7naD+/Q0aj6bB3Um2ZywGUd09cxsR42gsNE3QjKmcpCgQpl1ogVRI8HR9ku1J
+        noF8ZgpiFK3RmNHENDwaAKGCPv3VksqjX8a13zcdk6mN563yCGuS4Jo9MpD+5q4lcWon5oqlYHPQ
+        2L1uFm/D9VW70y4N7THetvVhGAzPHfPpXHVa7v/yhuHUOYFs4JF7ustRIAbBudNqt1vXrct/J34d
+        hJPTMyTpgnSdIrWf4f1kiiMWKdzp1Dk7TceE8bZBD9dPez0B8MsRsJkK4c7Caz5egI6Gj1CsbLAa
+        WmvO9h2XIw/vzTzPvEiSbMduEdd2XkQH4wJWKYskUzYVC8PPCutCrnE1vrHhREC4wpvn3FtFXVgR
+        08Va5uDhWqx35c4l+E2n6TacVsP5OHUvu81O171qOJeOUxIPkGX8L2L2zzz8+h8J/w87erp7lwgA
+        AA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Date:
+      - Thu, 03 Jun 2021 18:29:15 GMT
+      Keep-Alive:
+      - timeout=20
+      Set-Cookie:
+      - JSESSIONID="187415C6AED7ECF570890518635DECEB.app01.na06.prod.alma.dc01.hosted.exlibrisgroup.com:1801";
+        Version=1; Path=/; HttpOnly; SameSite=None; Secure
+      - urm_st=1622744954723; Path=/; SameSite=None; Secure
+      - urm_se=1622745554723; Path=/; SameSite=None; Secure
+      - X-Persist=92987b7c60597dcc378c0f98cc32abe8;Path=/;SameSite=None;Secure
+      Transfer-Encoding:
+      - chunked
+      p3p:
+      - CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi CONi HIS OUR IND CNT"
+      vary:
+      - accept-encoding
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,16 +1,11 @@
-from flask import request
+import os
 import pytest
 import redirector
 
 
 @pytest.fixture
 def client():
-    redirector.app.config['DEBUG'] = True
-    redirector.app.config['TESTING'] = True
-    redirector.app.config['TARGET_URL'] = 'http://example.com/hallo/'
-    redirector.app.config['ALMA_SRU'] = 'https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?version=1.2&operation=searchRetrieve&recordSchema=dc&query=alma.all_for_ui='
-    redirector.app.config['PRIMO_URL'] = 'http://example.com/primo/'
-
+    os.environ['FLASK_ENV'] = 'testing'
     with redirector.app.test_client() as client:
         yield client
 

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,11 +1,15 @@
+from flask import request
 import pytest
 import redirector
 
 
 @pytest.fixture
 def client():
+    redirector.app.config['DEBUG'] = True
     redirector.app.config['TESTING'] = True
     redirector.app.config['TARGET_URL'] = 'http://example.com/hallo/'
+    redirector.app.config['ALMA_SRU'] = 'https://mit.alma.exlibrisgroup.com/view/sru/01MIT_INST?version=1.2&operation=searchRetrieve&recordSchema=dc&query=alma.all_for_ui='
+    redirector.app.config['PRIMO_URL'] = 'http://example.com/primo/'
 
     with redirector.app.test_client() as client:
         yield client
@@ -28,7 +32,15 @@ def test_redirect_with_non_permalink_pattern(client):
     assert url in response.location
 
 
+@pytest.mark.vcr
 def test_redirect_with_permalink_pattern(client):
-    response = client.get('/item/123')
-    url = 'http://example.com/hallo/?aleph_id=123'
-    assert url in response.location
+    response = client.get('/item/000095961')
+    expected = 'http://example.com/primo/alma990000959610206761'
+    assert response.headers['location'] == expected
+
+
+@pytest.mark.vcr
+def test_redirect_to_generic_with_permalink_pattern_no_match(client):
+    response = client.get('/item/asdfasdfasfasdfasdfasdf')
+    expected = 'http://example.com/hallo/'
+    assert response.headers['location'] == expected


### PR DESCRIPTION
Why are these changes being introduced:

* Graceful degration of permalinks during system migration will be
  valuable to support both users with bookmarks, search engines, and
  web pages that cannot update to new links until after the new system
  goes live because the new permalinks are not yet known.

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2110

How does this address that need:

* This uses Alma SRU queries to look up an Aleph ID, obtain the Alma ID
and then contruct a URL to Primo UI.

Document any side effects to this change:

* It's possible redirecting directly to Primo UI is not the desired
solution. This work will still be useful if that is the case, as the URL
we generate in this would need to be passed to the generic transition
page if direct redirects are not desired.

* Future work to update old aleph permalinks on our internal web pages
is necessary before we can retire this system.