### PR TITLE
Adds support for Sentry exception monitoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: apt update
+         run: sudo apt update
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip pipenv

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ flask = "*"
 gunicorn = "*"
 requests = "*"
 pytest-recording = "*"
+sentry-sdk = {extras = ["flask"], version = "*"}
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9081bb805969d99b709c21c885473a6b00afbc1ea7c990d0ddbe4f35e9d07e84"
+            "sha256": "cb4720b7cc623ab4e309c045e7b1b241e7931843a373690f481f28ddfee11b62"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,12 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
+        },
+        "blinker": {
+            "hashes": [
+                "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"
+            ],
+            "version": "==1.4"
         },
         "certifi": {
             "hashes": [
@@ -179,11 +185,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
-                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.9"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
         },
         "pluggy": {
             "hashes": [
@@ -268,6 +274,17 @@
             "index": "pypi",
             "version": "==2.25.1"
         },
+        "sentry-sdk": {
+            "extras": [
+                "flask"
+            ],
+            "hashes": [
+                "sha256:593f6118cc6d3eba4786c3f802567c937bdb81b3c8e90436e8a29e84071c6936",
+                "sha256:9907adbdd30a55b818914512cc143e6beae0bb3ba78b2649f4b079752eb0e424"
+            ],
+            "index": "pypi",
+            "version": "==1.2.0"
+        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -286,11 +303,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.5"
+            "version": "==1.26.6"
         },
         "vcrpy": {
             "hashes": [
@@ -391,11 +408,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
-                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.9"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
         },
         "pluggy": {
             "hashes": [
@@ -447,11 +464,11 @@
         },
         "python-dotenv": {
             "hashes": [
-                "sha256:00aa34e92d992e9f8383730816359647f358f4a3be1ba45e5a5cefd27ee91544",
-                "sha256:b1ae5e9643d5ed987fc57cc2583021e38db531946518130777734f9589b3141f"
+                "sha256:dd8fe852847f4fbfadabf6183ddd4c824a9651f02d51714fa075c95561959c7d",
+                "sha256:effaac3c1e58d89b3ccb4d04a40dc7ad6e0275fda25fd75ae9d323e2465e202d"
             ],
             "index": "pypi",
-            "version": "==0.17.1"
+            "version": "==0.18.0"
         },
         "toml": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ Follow above development installation instructions.
 To (re)generate cassettes (cached responses)
 
 `pytest --record-mode=rewrite`
+
+## Environment variables
+
+  `ALMA_SRU`: SRU endpoint for Alma
+  `PRIMO_URL`: base URL to use to construct link to Primo UI
+  `SENTRY_DSN`: set to a valid Sentry DSN to enable exception monitoring
+  `TARGET_URL`: default URL to redirect to if no other match happens

--- a/redirector/__init__.py
+++ b/redirector/__init__.py
@@ -2,9 +2,17 @@ import logging
 import os
 
 import requests
+import sentry_sdk
 
 from flask import Flask, redirect
 from xml.etree.ElementTree import fromstring, ElementTree
+from sentry_sdk.integrations.flask import FlaskIntegration
+
+if os.getenv('SENTRY_DSN'):
+    sentry_sdk.init(
+        dsn=os.getenv('SENTRY_DSN'),
+        integrations=[FlaskIntegration()],
+    )
 
 app = Flask(__name__, instance_relative_config=True)
 
@@ -72,3 +80,8 @@ def alma_lookup(aleph_id):
         return f'{url}alma{alma_id.text}', code
 
     return url, code
+
+
+@app.route('/debug-sentry')
+def trigger_error():
+    division_by_zero = 1 / 0


### PR DESCRIPTION
Why are these changes being introduced:

* Configuring Sentry is part of our normal practices when launching
  applications into production

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/IMP-2154

How does this address that need:

* Follows standard Sentry documentation to implement monitoring

Side effects:

* Added apt-update to CI to improve stability in builds